### PR TITLE
Updated Chrome remote tab navigation

### DIFF
--- a/Main/Chrome/remote.lua
+++ b/Main/Chrome/remote.lua
@@ -1,4 +1,3 @@
-
 local task = libs.task;
 local keyboard = libs.keyboard;
 
@@ -37,13 +36,13 @@ end
 --@help Go to next tab
 actions.next_tab = function()
 	actions.switch();
-	keyboard.stroke("control", "shift", "tab");
+	keyboard.stroke("control", "tab");
 end
 
 --@help Go to previous tab
 actions.previous_tab = function()
 	actions.switch();
-	keyboard.stroke("control", "tab");
+	keyboard.stroke("control", "shift", "tab");
 end
 
 --@help Open new tab


### PR DESCRIPTION
The next_tab function now uses ctrl+tab and previous_tab use ctrl+shift+tab
