### PR TITLE
[Monitor Remote] Use x64 version of DisplaySwitch.exe if available

### DIFF
--- a/Main/Monitor/remote_win.lua
+++ b/Main/Monitor/remote_win.lua
@@ -5,6 +5,13 @@ local WM_SYSCOMMAND = 0x0112;
 local SC_MONITORPOWER = 0xF170;
 local HWND_BROADCAST = 0xffff;
 
+local display_switch_path = "%windir%/System32/DisplaySwitch.exe";
+ 
+-- Invoke the native version of DisplaySwitch is we're on x64 Windows...
+if os.getenv("PROCESSOR_ARCHITEW6432") == "AMD64" then
+    display_switch_path = "%windir%/Sysnative/DisplaySwitch.exe";
+end
+
 --@help Turn monitor on
 actions.turn_on = function()
 	mouse.moveby(0,0);
@@ -24,21 +31,21 @@ end
 
 --@help Duplicate desktop on multiple displays
 actions.clone = function()
-	os.start("%windir%/system32/DisplaySwitch.exe", "/clone");
+	os.start(display_switch_path, "/clone");
 end
 
 --@help Extend desktop on multiple displays
 actions.extend = function()
-	os.start("%windir%/system32/DisplaySwitch.exe", "/extend");
+	os.start(display_switch_path, "/extend");
 end
 
 --@help Display projector only
 actions.external = function()
-	os.start("%windir%/system32/DisplaySwitch.exe", "/external");
+	os.start(display_switch_path, "/external");
 end
 
 --@help Display computer only
 actions.internal = function()
-	os.start("%windir%/system32/DisplaySwitch.exe", "/internal");
+	os.start(display_switch_path, "/internal");
 end
 


### PR DESCRIPTION
This will make the "Monitor" remote use the native version of DisplaySwitch.exe if the user is running a x64 version of Windows. It seems that Microsoft removed the x86 executable in one of the recent Windows 10 insider builds (noticed on build 15014) and thus breaking the monitor output switching functionality.

You can read up on "File System Redirector", which manifests the issue here:

https://msdn.microsoft.com/en-us/library/windows/desktop/aa384187.aspx