### PR TITLE
Update netflix web fullscreen button

### DIFF
--- a/Main/Netflix/remote_win.lua
+++ b/Main/Netflix/remote_win.lua
@@ -113,7 +113,6 @@ end
 --@help Fullscreen view
 actions.fullscreen = function()
 	actions.switch();
-	keyboard.stroke("F11");
 	keyboard.stroke("F");
 end
 
@@ -121,6 +120,5 @@ end
 actions.window = function()
 	actions.switch();
 	keyboard.stroke("escape");
-	keyboard.stroke("F11");
 end
 


### PR DESCRIPTION
There is no need to set browser windows to be in fullscreen mode. Setting netflix to fullscreen playback ("f" keystroke) is suffucient and less confusing. It also eliminates the need for separate button for windowed mode, as "f" keystroke works as toggle in netflix.