### PR TITLE
Added SKIP INTRO for non windows OS

### DIFF
--- a/Main/Netflix/layout.xml
+++ b/Main/Netflix/layout.xml
@@ -19,6 +19,7 @@
 	<row>
       <button icon="fullscreen" onTap="fullscreen" />
       <button text="Esc" onTap="window" />
+      <button text="Skip Intro" onTap="skip_intro" />
     </row>
   </grid>
 </layout>

--- a/Main/Netflix/remote.lua
+++ b/Main/Netflix/remote.lua
@@ -60,6 +60,11 @@ actions.fullscreen = function()
 	keyboard.stroke("F");
 end
 
+--@help Skip Intro
+actions.skip_intro = function()
+	keyboard.stroke("s");
+end
+
 --@help Windowed view
 actions.window = function()
 	keyboard.stroke("escape");


### PR DESCRIPTION
This should add the "Skip intro" option for MacOS and Linux. Although I only tried it in the latter one.