### PR TITLE
Adjust volume from phone physical buttons for Plex Keyboard Remote

### DIFF
--- a/Main/Plex Keyboard/layout.xml
+++ b/Main/Plex Keyboard/layout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout onlaunch="launch" color="#FF9500">
+<layout onlaunch="launch" onVolumeUp="volume_up" onVolumeDown="volume_down" color="#FF9500">
 	<tabs>
 		<tab text="Main">
 			<row>

--- a/Main/Plex Keyboard/remote.lua
+++ b/Main/Plex Keyboard/remote.lua
@@ -134,3 +134,15 @@ actions.info = function ()
 	actions.switch();
 	kb.press("i");
 end
+
+--@help Volume Down
+actions.volume_down = function ()
+	actions.switch();
+	kb.press("volumedown")
+end
+
+--@help Volume Up
+actions.volume_up = function ()
+	actions.switch();
+	kb.press("volumeup")
+end


### PR DESCRIPTION
Pretty much the title, I thought it was annoying not being able to change the volume from the Plex remote. I could only test this on Linux btw, sorry.