### PR TITLE
German Keyboard - mixed up Y and Z

### DIFF
--- a/Main/Keyboards/German/remote.lua
+++ b/Main/Keyboards/German/remote.lua
@@ -6,9 +6,9 @@ include("../keyboard.lua");
 -- Layout
 keys = {
 	{ "ESCAPE", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0" },
-	{ "TAB", "Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P", "Ü" }, 
+	{ "TAB", "Q", "W", "E", "R", "T", "Z", "U", "I", "O", "P", "Ü" }, 
 	{ "CAPITAL", "A", "S", "D", "F", "G", "H", "J", "K", "L", "Ö", "Ä" },
-	{ "SHIFT", "Z", "X", "C", "V", "B", "N", "M", "COMMA", ".", "-", "BACK" },
+	{ "SHIFT", "Y", "X", "C", "V", "B", "N", "M", "COMMA", ".", "-", "BACK" },
 	{ "FN", "CONTROL", "LWIN", "MENU", "SPACE", "RMENU", "RETURN" } 
 };
 


### PR DESCRIPTION
Keys Y and Z are mixed up. 
On German keyboard layout the Z is right of the T, left of the U. The Y is left of the X.
So this was the English keyboard position of Z and Y.