### PR TITLE
Add Raise/Lower Hand button to Zoom remote

### DIFF
--- a/Main/Zoom/README.md
+++ b/Main/Zoom/README.md
@@ -4,6 +4,7 @@ Zoom meeting remote.
 ## Features
 *  Toggle Mute
 *  Toggle Video
+*  Raise/Lower Hand
 *  Share screen
 *  Record
 *  End meeting

--- a/Main/Zoom/layout.xml
+++ b/Main/Zoom/layout.xml
@@ -8,6 +8,9 @@
       <button text="Video" onTap="video" />
     </row>
     <row>
+      <button text="Raise/Lower Hand" onTap="hand" />
+    </row>
+    <row>
       <button text="Share Screen" onTap="screen" />
     </row>
     <row>

--- a/Main/Zoom/remote.lua
+++ b/Main/Zoom/remote.lua
@@ -34,6 +34,12 @@ actions.video = function()
 	keyboard.stroke("alt", "v");
 end
 
+--@help Raise/Lower Hand
+actions.hand = function()
+	actions.switch();
+	keyboard.stroke("alt", "y");
+end
+
 --@help Share screen
 actions.screen = function()
 	actions.switch();


### PR DESCRIPTION
This is convenient for toggling hand when a meeting participant, allowing full functionality without using a keyboard.