### PR TITLE
Fix Linux Wayland Mouse Click Input Issue (#140)

### DIFF
--- a/Core/Input/remote.lua
+++ b/Core/Input/remote.lua
@@ -30,7 +30,8 @@ actions.MouseUp = function(...)
 end
 
 actions.Click = function(...)
-	mouse.click(unpack({...}));
+	mouse.down(unpack({...}));
+	mouse.up(unpack({...}));
 end
 
 actions.DblClick = function(...)


### PR DESCRIPTION
Replaced `mouse.click()` with `mouse.down()` followed by `mouse.up()` to address input issues on Linux Wayland (tested on KDE kwin_wayland). This change also ensures continued compatibility with other platforms, including Windows and various Linux environments, preserving consistent and reliable mouse interaction across all supported systems.